### PR TITLE
feat(auth): Google sign-in and sign-up

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ NEXT_PUBLIC_BACKEND_URL=https://hemocione-id-dev.cpt.hemocione.com.br/
 NEXT_PUBLIC_SITE_KEY=xxxxx
 NEXT_PUBLIC_MAIN_FRONTEND_URL=https://d.hemocione.com.br/
 NEXT_PUBLIC_TOKEN_COOKIE_KEY=devHemocioneId
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=xxxxx.apps.googleusercontent.com
 
 NEXT_PUBLIC_LEGAL_PRIVACY_POLICY_URL=google.com
 NEXT_PUBLIC_LEGAL_TERMS_OF_USE_URL=google.com

--- a/components/GoogleAuthButton/GoogleAuthButton.jsx
+++ b/components/GoogleAuthButton/GoogleAuthButton.jsx
@@ -1,0 +1,38 @@
+import { GoogleLogin } from "@react-oauth/google";
+import { googleAuth } from "../../utils/api";
+import environment from "../../environment";
+
+const GoogleAuthButton = ({ onLogin, onSignupRequired, onError }) => {
+  if (!environment.googleClientId) return null;
+
+  const handleSuccess = async (credentialResponse) => {
+    try {
+      const credential = credentialResponse.credential;
+      const response = await googleAuth({ credential });
+      if (response.data?.status === "signup_required") {
+        onSignupRequired({ credential, profile: response.data.profile });
+        return;
+      }
+      onLogin(response.data);
+    } catch (error) {
+      console.error(error);
+      onError(
+        error.response?.data?.message ||
+          "Ocorreu um erro inesperado. Por favor, tente novamente."
+      );
+    }
+  };
+
+  return (
+    <GoogleLogin
+      onSuccess={handleSuccess}
+      onError={() =>
+        onError("Não foi possível entrar com o Google. Tente novamente.")
+      }
+      text="continue_with"
+      locale="pt_BR"
+    />
+  );
+};
+
+export default GoogleAuthButton;

--- a/components/GoogleAuthButton/GoogleAuthButton.jsx
+++ b/components/GoogleAuthButton/GoogleAuthButton.jsx
@@ -1,11 +1,16 @@
+import { useRef } from "react";
 import { GoogleLogin } from "@react-oauth/google";
 import { googleAuth } from "../../utils/api";
 import environment from "../../environment";
 
 const GoogleAuthButton = ({ onLogin, onSignupRequired, onError }) => {
+  const pendingRef = useRef(false);
+
   if (!environment.googleClientId) return null;
 
   const handleSuccess = async (credentialResponse) => {
+    if (pendingRef.current) return;
+    pendingRef.current = true;
     try {
       const credential = credentialResponse.credential;
       const response = await googleAuth({ credential });
@@ -20,6 +25,8 @@ const GoogleAuthButton = ({ onLogin, onSignupRequired, onError }) => {
         error.response?.data?.message ||
           "Ocorreu um erro inesperado. Por favor, tente novamente."
       );
+    } finally {
+      pendingRef.current = false;
     }
   };
 

--- a/components/LoginSection/LoginSection.jsx
+++ b/components/LoginSection/LoginSection.jsx
@@ -137,6 +137,7 @@ const LoginSection = () => {
   const handleAcceptTerms = () => {
     setAcceptingTerms(true);
     if (!loggedInToken) {
+      setAcceptingTerms(false);
       return;
     }
 

--- a/components/LoginSection/LoginSection.jsx
+++ b/components/LoginSection/LoginSection.jsx
@@ -3,7 +3,7 @@ import Visibility from "@mui/icons-material/Visibility";
 import VisibilityOff from "@mui/icons-material/VisibilityOff";
 import { useState } from "react";
 import Image from "next/image";
-import { SimpleButton } from "..";
+import { SimpleButton, GoogleAuthButton } from "..";
 import { validateEmail } from "../../utils/validators";
 import { login, acceptTerms } from "../../utils/api";
 import { setCookie } from "../../utils/cookie";
@@ -99,6 +99,29 @@ const LoginSection = () => {
             "Ocorreu um erro inesperado. Por favor, tente novamente."
         );
       });
+  };
+
+  const handleGoogleLogin = (data) => {
+    setLoggedInToken(data.token);
+
+    if (data.requestNewTermsAcceptance) {
+      setTermsAcceptanceDrawer(true);
+      return;
+    }
+
+    finishLogin(data.token);
+  };
+
+  const handleGoogleSignupRequired = ({ credential, profile }) => {
+    sessionStorage.setItem(
+      "hemocioneGoogleSignup",
+      JSON.stringify({ credential, profile })
+    );
+    router.push(
+      encodedRedirect
+        ? `/signup?redirect=${encodedRedirect}&google=1`
+        : "/signup?google=1"
+    );
   };
 
   const handleEmailChange = (e) => {
@@ -238,6 +261,20 @@ const LoginSection = () => {
             >
               Entrar
             </SimpleButton>
+          )}
+          {environment.googleClientId && (
+            <>
+              <div className={styles.orDivider}>
+                <span>ou</span>
+              </div>
+              <div className={styles.googleButtonRow}>
+                <GoogleAuthButton
+                  onLogin={handleGoogleLogin}
+                  onSignupRequired={handleGoogleSignupRequired}
+                  onError={setErrorText}
+                />
+              </div>
+            </>
           )}
         </div>
       </form>

--- a/components/LoginSection/LoginSection.module.css
+++ b/components/LoginSection/LoginSection.module.css
@@ -54,3 +54,26 @@
       box-shadow: none;
   }
 }
+.orDivider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  margin: 16px 0 12px;
+  color: #888;
+  font-size: 0.9rem;
+}
+
+.orDivider::before,
+.orDivider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background-color: #ddd;
+}
+
+.googleButtonRow {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}

--- a/components/SignupSection/SignupSection.jsx
+++ b/components/SignupSection/SignupSection.jsx
@@ -128,7 +128,7 @@ const SignupSection = () => {
       console.error(error);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router.isReady]);
+  }, [router.isReady, router.query.google]);
 
   const handleGoogleLogin = (data) => {
     // account already exists: behave like a login

--- a/components/SignupSection/SignupSection.jsx
+++ b/components/SignupSection/SignupSection.jsx
@@ -11,7 +11,7 @@ import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { ptBR } from "date-fns/locale";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import {
   validateEmail,
@@ -33,7 +33,14 @@ import useDebounce from "../../utils/useDebounce";
 import environment from "../../environment";
 import { getDigitalStandRedirectUrl } from "../../utils/digitalStand";
 import { ptBR as DatePickerLocale } from "@mui/x-date-pickers/locales";
-import { SimpleButton, CepMask, PhoneMask, BloodType, CpfMask } from "..";
+import {
+  SimpleButton,
+  CepMask,
+  PhoneMask,
+  BloodType,
+  CpfMask,
+  GoogleAuthButton,
+} from "..";
 import _ from "lodash";
 import { mobileUrls } from "../../utils/mobile";
 
@@ -90,6 +97,59 @@ const SignupSection = () => {
   const [acceptedTerms, setAcceptedTerms] = useState(false);
   const [acceptedPrivacyPolicy, setAcceptedPrivacyPolicy] = useState(false);
   const [acceptedMarketingConsent, setAcceptedMarketingConsent] = useState(false);
+  const [googleSignup, setGoogleSignup] = useState(null);
+
+  const enterGoogleMode = ({ credential, profile }) => {
+    setGoogleSignup({ credential, profile });
+    setSignupData((current) => ({
+      ...current,
+      givenName: profile?.givenName || current.givenName,
+      surName: profile?.surName || current.surName,
+      email: profile?.email || current.email,
+      password: "",
+      passConfirmation: "",
+    }));
+  };
+
+  const exitGoogleMode = () => {
+    setGoogleSignup(null);
+    sessionStorage.removeItem("hemocioneGoogleSignup");
+  };
+
+  useEffect(() => {
+    if (!router.isReady || !router.query.google) return;
+    try {
+      const stored = sessionStorage.getItem("hemocioneGoogleSignup");
+      if (!stored) return;
+      const parsed = JSON.parse(stored);
+      if (!parsed?.credential) return;
+      enterGoogleMode(parsed);
+    } catch (error) {
+      console.error(error);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.isReady]);
+
+  const handleGoogleLogin = (data) => {
+    // account already exists: behave like a login
+    setCookie(environment.tokenCookieKey, data.token, 15, "hemocione.com.br");
+    const locationRedirect =
+      redirect || environment.mainFrontendUrl || "https://app.hemocione.com.br/";
+    const url = new URL(locationRedirect);
+    if (
+      url.hostname.endsWith("hemocione.com.br") ||
+      window.location.hostname.endsWith("id.d.hemocione.com.br") ||
+      mobileUrls.some((mobileUrl) => url.toString().startsWith(mobileUrl))
+    ) {
+      url.searchParams.append("token", data.token);
+    }
+    window.open(url.toString(), "_self");
+  };
+
+  const handleGoogleSignupRequired = (data) => {
+    sessionStorage.setItem("hemocioneGoogleSignup", JSON.stringify(data));
+    enterGoogleMode(data);
+  };
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -127,10 +187,17 @@ const SignupSection = () => {
       marketingConsent: acceptedMarketingConsent,
     };
 
+    if (googleSignup) {
+      hydratedSignUpData.googleCredential = googleSignup.credential;
+      delete hydratedSignUpData.password;
+      delete hydratedSignUpData.passConfirmation;
+    }
+
     signUp(hydratedSignUpData, options)
       .then((response) => {
         setLoading(false);
         if ([200, 201].includes(response.status)) {
+          sessionStorage.removeItem("hemocioneGoogleSignup");
           if (response.data["token"]) {
             setCookie(
               environment.tokenCookieKey,
@@ -259,20 +326,24 @@ const SignupSection = () => {
 
   const validBloodSelection = unknownBloodType || signupData.bloodType;
 
+  const passwordOk = googleSignup
+    ? true
+    : signupData.password &&
+      signupData.passConfirmation &&
+      !passError &&
+      !passConfError;
+
   const disabledButton =
     !signupData.givenName ||
     !signupData.surName ||
     !validBloodSelection ||
     !signupData.email ||
-    !signupData.password ||
-    !signupData.passConfirmation ||
+    !passwordOk ||
     !signupData.gender ||
     !signupData.birthDate ||
     !signupData.address.cep ||
     !signupData.document ||
     cpfError ||
-    passConfError ||
-    passError ||
     emailError ||
     phoneError ||
     !acceptedTerms ||
@@ -293,6 +364,29 @@ const SignupSection = () => {
             Faça parte da Rede Hemocione de doadores e ajude a salvar vidas!
           </span> */}
         </div>
+        {environment.googleClientId && !googleSignup && (
+          <>
+            <div className={styles.googleButtonRow}>
+              <GoogleAuthButton
+                onLogin={handleGoogleLogin}
+                onSignupRequired={handleGoogleSignupRequired}
+                onError={setErrorText}
+              />
+            </div>
+            <div className={styles.orDivider}>
+              <span>ou</span>
+            </div>
+          </>
+        )}
+        {googleSignup && (
+          <div className={styles.googleSignupBanner}>
+            <span>
+              Cadastrando com a conta Google{" "}
+              <b>{googleSignup.profile?.email}</b> — sem necessidade de senha.
+            </span>
+            <a onClick={exitGoogleMode}>Prefiro usar email e senha</a>
+          </div>
+        )}
         <FormGroup onSubmit={handleSubmit}>
           <FormControl fullWidth sx={{ margin: "15px 0" }}>
             <TextField
@@ -328,6 +422,7 @@ const SignupSection = () => {
               name="email"
               variant="outlined"
               autoComplete="username"
+              disabled={Boolean(googleSignup)}
               required
             />
           </FormControl>
@@ -549,37 +644,41 @@ const SignupSection = () => {
             </FormControl>
           </div>
           <hr className={styles.divider} />
-          <FormControl fullWidth sx={{ marginBottom: "15px" }}>
-            <TextField
-              fullWidth
-              onChange={handleChange("password")}
-              value={signupData.password}
-              error={passError}
-              helperText={
-                passError && "A senha deve ter pelo menos 7 caracteres"
-              }
-              id="password"
-              name="password"
-              label="Senha"
-              type="password"
-              variant="outlined"
-              required
-            />
-          </FormControl>
-          <FormControl fullWidth sx={{ marginBottom: "15px" }}>
-            <TextField
-              fullWidth
-              onChange={handleChange("passConfirmation")}
-              error={passConfError}
-              value={signupData.passConfirmation}
-              id="password-confirmation"
-              name="password-confirmation"
-              label="Confirmar senha"
-              type="password"
-              variant="outlined"
-              required
-            />
-          </FormControl>
+          {!googleSignup && (
+            <>
+              <FormControl fullWidth sx={{ marginBottom: "15px" }}>
+                <TextField
+                  fullWidth
+                  onChange={handleChange("password")}
+                  value={signupData.password}
+                  error={passError}
+                  helperText={
+                    passError && "A senha deve ter pelo menos 7 caracteres"
+                  }
+                  id="password"
+                  name="password"
+                  label="Senha"
+                  type="password"
+                  variant="outlined"
+                  required
+                />
+              </FormControl>
+              <FormControl fullWidth sx={{ marginBottom: "15px" }}>
+                <TextField
+                  fullWidth
+                  onChange={handleChange("passConfirmation")}
+                  error={passConfError}
+                  value={signupData.passConfirmation}
+                  id="password-confirmation"
+                  name="password-confirmation"
+                  label="Confirmar senha"
+                  type="password"
+                  variant="outlined"
+                  required
+                />
+              </FormControl>
+            </>
+          )}
           <div className={styles.checkBoxRow}>
             <Checkbox
               checked={acceptedTerms}

--- a/components/SignupSection/SignupSection.jsx
+++ b/components/SignupSection/SignupSection.jsx
@@ -134,7 +134,9 @@ const SignupSection = () => {
     // account already exists: behave like a login
     setCookie(environment.tokenCookieKey, data.token, 15, "hemocione.com.br");
     const locationRedirect =
-      redirect || environment.mainFrontendUrl || "https://app.hemocione.com.br/";
+      redirect ||
+      environment.mainFrontendUrl ||
+      "https://app.hemocione.com.br/";
     const url = new URL(locationRedirect);
     if (
       url.hostname.endsWith("hemocione.com.br") ||

--- a/components/SignupSection/SignupSection.module.css
+++ b/components/SignupSection/SignupSection.module.css
@@ -139,3 +139,48 @@
     box-shadow: none;
   }
 }
+
+.orDivider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  margin: 12px 0;
+  color: #888;
+  font-size: 0.9rem;
+}
+
+.orDivider::before,
+.orDivider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background-color: #ddd;
+}
+
+.googleButtonRow {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+.googleSignupBanner {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+  padding: 12px 16px;
+  margin-bottom: 15px;
+  background-color: #fdecea;
+  border: 1px solid rgba(209, 21, 26, 0.25);
+  border-radius: 8px;
+  font-size: 0.9rem;
+  box-sizing: border-box;
+}
+
+.googleSignupBanner a {
+  color: #d1151a;
+  font-weight: 700;
+  cursor: pointer;
+  text-decoration: underline;
+}

--- a/components/index.js
+++ b/components/index.js
@@ -6,6 +6,7 @@ export { default as Navbar } from "./Navbar/Navbar";
 export { default as SimpleButton } from "./SimpleButton/SimpleButton";
 export { default as Background } from "./Background/Background";
 export { default as BloodType } from "./BloodType/BloodType";
+export { default as GoogleAuthButton } from "./GoogleAuthButton/GoogleAuthButton";
 export { default as PhoneMask } from "./common/PhoneMask/PhoneMask";
 export { default as CepMask } from "./common/CepMask/CepMask";
 export { default as CpfMask } from "./common/CpfMask/CpfMask";

--- a/environment.js
+++ b/environment.js
@@ -3,6 +3,7 @@ const environment = {
   publicSiteKey: process.env.NEXT_PUBLIC_SITE_KEY,
   mainFrontendUrl: process.env.NEXT_PUBLIC_MAIN_FRONTEND_URL,
   tokenCookieKey: process.env.NEXT_PUBLIC_TOKEN_COOKIE_KEY,
+  googleClientId: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID,
   legal: {
     privacyPolicyUrl: process.env.NEXT_PUBLIC_LEGAL_PRIVACY_POLICY_URL,
     termsOfUse: process.env.NEXT_PUBLIC_LEGAL_TERMS_OF_USE_URL,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/material": "^5.11.6",
         "@mui/x-data-grid": "^6.16.1",
         "@mui/x-date-pickers": "^5.0.0-alpha.2",
+        "@react-oauth/google": "^0.13.5",
         "axios": "^1.6.2",
         "date-fns": "^2.28.0",
         "lodash": "^4.17.21",
@@ -1557,6 +1558,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@react-oauth/google": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.13.5.tgz",
+      "integrity": "sha512-xQWri2s/3nNekZJ4uuov2aAfQYu83bN3864KcFqw2pK1nNbFurQIjPFDXhWaKH3IjYJ2r/9yyIIpsn5lMqrheQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@rushstack/eslint-patch": {
@@ -6180,6 +6191,12 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
+    },
+    "@react-oauth/google": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.13.5.tgz",
+      "integrity": "sha512-xQWri2s/3nNekZJ4uuov2aAfQYu83bN3864KcFqw2pK1nNbFurQIjPFDXhWaKH3IjYJ2r/9yyIIpsn5lMqrheQ==",
+      "requires": {}
     },
     "@rushstack/eslint-patch": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@mui/material": "^5.11.6",
     "@mui/x-data-grid": "^6.16.1",
     "@mui/x-date-pickers": "^5.0.0-alpha.2",
+    "@react-oauth/google": "^0.13.5",
     "axios": "^1.6.2",
     "date-fns": "^2.28.0",
     "lodash": "^4.17.21",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -8,10 +8,28 @@ import { createTheme, ThemeProvider } from "@mui/material/styles";
 import { ptBR } from "@mui/material/locale";
 import { ptBR as datePickerPtBR } from "@mui/x-date-pickers/locales";
 import { ptBR as dataGridPtBR } from "@mui/x-data-grid";
+import { GoogleOAuthProvider } from "@react-oauth/google";
+import environment from "../environment";
 
 const theme = createTheme({}, ptBR, datePickerPtBR, dataGridPtBR);
 
 function MyApp({ Component, pageProps }) {
+  const content = (
+    <ThemeProvider theme={theme}>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          width: "100vw",
+        }}
+      >
+        {/* <Navbar /> */}
+        <Component {...pageProps} />
+      </div>
+    </ThemeProvider>
+  );
+
   return (
     <>
       <Head>
@@ -45,19 +63,13 @@ function MyApp({ Component, pageProps }) {
         <meta name="msapplication-navbutton-color" content="#FF0000" />
         <meta name="apple-mobile-web-app-status-bar-style" content="#FF0000" />
       </Head>
-      <ThemeProvider theme={theme}>
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            width: "100vw",
-          }}
-        >
-          {/* <Navbar /> */}
-          <Component {...pageProps} />
-        </div>
-      </ThemeProvider>
+      {environment.googleClientId ? (
+        <GoogleOAuthProvider clientId={environment.googleClientId}>
+          {content}
+        </GoogleOAuthProvider>
+      ) : (
+        content
+      )}
     </>
   );
 }

--- a/utils/api.js
+++ b/utils/api.js
@@ -16,6 +16,11 @@ const login = ({ email, password, captchaToken }) => {
     "g-recaptcha-response": captchaToken,
   });
 };
+const googleAuth = ({ credential }) => {
+  return apiClient.post(`/users/auth/google`, {
+    credential: credential,
+  });
+};
 const signUp = (signUpData, queryParams, captchaToken = "") => {
   return apiClient.post(
     `/users/register`,
@@ -67,4 +72,4 @@ const acceptTerms = ({ token }) => {
   });
 }
 
-export { login, signUp, validateUserToken, recoverPassword, resetPassword, acceptTerms };
+export { login, googleAuth, signUp, validateUserToken, recoverPassword, resetPassword, acceptTerms };


### PR DESCRIPTION
## What

Adds a **Continue with Google** button (`@react-oauth/google`) to the login and signup pages.

- **Login page:** Google button below the password form. Existing accounts log straight in through the same `finishLogin` flow (cross-subdomain cookie + token in redirect URL + new-terms drawer). If the account doesn't exist, the credential goes to `sessionStorage` (never the URL) and the user lands on `/signup?google=1`.
- **Signup page (Google mode):** email prefilled and locked to the Google account, name prefilled (editable), password fields hidden. **Every other field stays required** — blood type, birth date, gender, phone, CPF, address and consents — so no registration data is lost. Submit sends `googleCredential` instead of a password. A banner shows which Google account is being used, with an opt-out link back to email+password.
- Everything only renders when `NEXT_PUBLIC_GOOGLE_CLIENT_ID` is set, so the feature can be toggled per environment.

## Config required before enabling

- Same OAuth Client ID as the backend, with authorized JavaScript origins for `id.hemocione.com.br`, `id.d.hemocione.com.br` and `http://localhost:3000`.
- Set `NEXT_PUBLIC_GOOGLE_CLIENT_ID` (added to `.env.example`).

## Notes

- `next build` green; prettier/lint errors reported on these files are pre-existing drift from `master` (new code is clean).

Pairs with Hemocione/hemocione-id#29 — the backend must be deployed first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Google authentication is now available for login and signup.
  * Users can authenticate using their Google account alongside traditional email/password options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->